### PR TITLE
Code coverage marker

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "futures",
  "futures-util",
  "headers",
+ "hyper",
  "jsonwebtoken",
  "lazy_static",
  "lettre",
@@ -1594,13 +1595,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1608,6 +1610,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -26,7 +26,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 
 # Async and concurrency
 tokio = { version = "1.0", features = ["full"] }
-
+hyper = { version = "1.7.0", features = ["full"] }
 # Serialization and validation
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/backend/api/src/routes/modules/assignments/mark_allocator/post.rs
+++ b/backend/api/src/routes/modules/assignments/mark_allocator/post.rs
@@ -103,10 +103,10 @@ pub async fn generate(
         }
     };
 
-    // let memo_dir = MemoOutputModel::full_directory_path(module_id, assignment_id);
+    let memo_dir = MemoOutputModel::full_directory_path(module_id, assignment_id);
     let mut task_file_pairs = vec![];
 
-    for task in tasks.iter().filter(|t| !t.code_coverage) {
+    for task in &tasks {
         let task_info = TaskInfo {
             id: task.id,
             task_number: task.task_number,
@@ -118,23 +118,15 @@ pub async fn generate(
             },
         };
 
-        let memo_output = match assignment_memo_output::Entity::find()
+        let memo_output_res = assignment_memo_output::Entity::find()
             .filter(assignment_memo_output::Column::AssignmentId.eq(assignment_id))
             .filter(assignment_memo_output::Column::TaskId.eq(task.id))
             .one(db)
-            .await
-        {
-            Ok(Some(m)) => m,
-            Ok(None) => {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(ApiResponse::<()>::error(format!(
-                        "Memo output not found for task {}",
-                        task.id
-                    ))),
-                )
-                    .into_response();
-            }
+            .await;
+
+        let memo_path = match memo_output_res {
+            Ok(Some(memo_output)) => MemoOutputModel::storage_root().join(&memo_output.path),
+            Ok(None) => memo_dir.join(format!("no_memo_for_task_{}", task.id)),
             Err(_) => {
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -144,7 +136,6 @@ pub async fn generate(
             }
         };
 
-        let memo_path = MemoOutputModel::storage_root().join(&memo_output.path);
         task_file_pairs.push((task_info, memo_path));
     }
 

--- a/backend/api/src/routes/modules/assignments/submissions/post.rs
+++ b/backend/api/src/routes/modules/assignments/submissions/post.rs
@@ -8,6 +8,9 @@ use axum::{
 };
 use chrono::Utc;
 use code_runner;
+use db::models::assignment_memo_output;
+use db::models::assignment_memo_output::Model as MemoOutputModel;
+use db::models::assignment_task;
 use db::models::{
     assignment::{Column as AssignmentColumn, Entity as AssignmentEntity},
     assignment_submission::{self, Model as AssignmentSubmissionModel},
@@ -19,13 +22,13 @@ use md5;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 use serde::{Deserialize, Serialize};
 use tokio_util::bytes;
+use util::mark_allocator::mark_allocator::TaskInfo;
 use util::{
     execution_config::{ExecutionConfig, execution_config::SubmissionMode},
     mark_allocator::mark_allocator::generate_allocator,
     mark_allocator::mark_allocator::load_allocator,
     state::AppState,
 };
-
 #[derive(Debug, Deserialize)]
 pub struct RemarkRequest {
     #[serde(default)]
@@ -761,7 +764,69 @@ pub async fn submit_assignment(
     }
 
     if config.project.submission_mode != SubmissionMode::Manual {
-        if let Err(_) = generate_allocator(module_id, assignment_id).await {
+        let tasks_res = assignment_task::Entity::find()
+            .filter(assignment_task::Column::AssignmentId.eq(assignment_id))
+            .all(db)
+            .await;
+
+        let tasks = match tasks_res {
+            Ok(t) => t,
+            Err(_) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ApiResponse::<SubmissionDetailResponse>::error(
+                        "Failed to fetch assignment tasks",
+                    )),
+                );
+            }
+        };
+
+        // let memo_dir = MemoOutputModel::full_directory_path(module_id, assignment_id);
+        let mut task_file_pairs = vec![];
+
+        for task in tasks.iter().filter(|t| !t.code_coverage) {
+            let task_info = TaskInfo {
+                id: task.id,
+                task_number: task.task_number,
+                code_coverage: task.code_coverage,
+                name: if task.name.trim().is_empty() {
+                    format!("Task {}", task.task_number)
+                } else {
+                    task.name.clone()
+                },
+            };
+
+            let memo_output = match assignment_memo_output::Entity::find()
+                .filter(assignment_memo_output::Column::AssignmentId.eq(assignment_id))
+                .filter(assignment_memo_output::Column::TaskId.eq(task.id))
+                .one(db)
+                .await
+            {
+                Ok(Some(m)) => m,
+                Ok(None) => {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(ApiResponse::<SubmissionDetailResponse>::error(format!(
+                            "Memo output not found for task {}",
+                            task.id
+                        ))),
+                    );
+                }
+                Err(_) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ApiResponse::<SubmissionDetailResponse>::error(
+                            "Failed to fetch memo output",
+                        )),
+                    );
+                }
+            };
+
+            let memo_path = MemoOutputModel::storage_root().join(&memo_output.path);
+            task_file_pairs.push((task_info, memo_path));
+        }
+
+        if let Err(_) = generate_allocator(module_id, assignment_id, &task_file_pairs).await {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ApiResponse::<SubmissionDetailResponse>::error(

--- a/backend/api/tests/routes/modules/assignments/mark_allocator/post_test.rs
+++ b/backend/api/tests/routes/modules/assignments/mark_allocator/post_test.rs
@@ -7,13 +7,11 @@ mod tests {
         http::{Request, StatusCode},
     };
     use chrono::{TimeZone, Utc};
-    use db::{
-        models::{
-            assignment::Model as AssignmentModel,
-            module::Model as ModuleModel,
-            user::Model as UserModel,
-            user_module_role::{Model as UserModuleRoleModel, Role},
-        }
+    use db::models::{
+        assignment::Model as AssignmentModel,
+        module::Model as ModuleModel,
+        user::Model as UserModel,
+        user_module_role::{Model as UserModuleRoleModel, Role},
     };
     use serial_test::serial;
     use std::{fs, path::PathBuf};
@@ -112,28 +110,30 @@ mod tests {
         let _ = fs::remove_dir_all("./tmp");
     }
 
-    #[tokio::test]
-    #[serial]
-    async fn test_post_mark_allocator_not_found() {
-        setup_assignment_storage_root();
-        let (app, app_state) = make_test_app().await;
-        let data = setup_test_data(app_state.db()).await;
+    //Commented out due to change in mark_allocator functionality - test no longer applies
 
-        let (token, _) = generate_jwt(data.lecturer_user.id, data.lecturer_user.admin);
-        let uri = format!(
-            "/api/modules/{}/assignments/{}/mark_allocator/generate",
-            data.module.id, data.assignment.id
-        );
-        let req = Request::builder()
-            .method("POST")
-            .uri(&uri)
-            .header("Authorization", format!("Bearer {}", token))
-            .body(Body::empty())
-            .unwrap();
+    // #[tokio::test]
+    // #[serial]
+    // async fn test_post_mark_allocator_not_found() {
+    //     setup_assignment_storage_root();
+    //     let (app, app_state) = make_test_app().await;
+    //     let data = setup_test_data(app_state.db()).await;
 
-        let response = app.oneshot(req).await.unwrap();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
+    //     let (token, _) = generate_jwt(data.lecturer_user.id, data.lecturer_user.admin);
+    //     let uri = format!(
+    //         "/api/modules/{}/assignments/{}/mark_allocator/generate",
+    //         data.module.id, data.assignment.id
+    //     );
+    //     let req = Request::builder()
+    //         .method("POST")
+    //         .uri(&uri)
+    //         .header("Authorization", format!("Bearer {}", token))
+    //         .body(Body::empty())
+    //         .unwrap();
+
+    //     let response = app.oneshot(req).await.unwrap();
+    //     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    // }
 
     #[tokio::test]
     #[serial]
@@ -202,50 +202,52 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
-    #[tokio::test]
-    #[serial]
-    async fn test_post_mark_allocator_missing_memo_or_config() {
-        setup_assignment_storage_root();
-        let (app, app_state) = make_test_app().await;
-        let data = setup_test_data(app_state.db()).await;
+    //Commented out due to change in mark_allocator functionality - test no longer applies
 
-        let (token, _) = generate_jwt(data.lecturer_user.id, data.lecturer_user.admin);
-        let uri = format!(
-            "/api/modules/{}/assignments/{}/mark_allocator/generate",
-            data.module.id, data.assignment.id
-        );
-        let req = Request::builder()
-            .method("POST")
-            .uri(&uri)
-            .header("Authorization", format!("Bearer {}", token))
-            .body(Body::empty())
-            .unwrap();
+    // #[tokio::test]
+    // #[serial]
+    // async fn test_post_mark_allocator_missing_memo_or_config() {
+    //     setup_assignment_storage_root();
+    //     let (app, app_state) = make_test_app().await;
+    //     let data = setup_test_data(app_state.db()).await;
 
-        let response = app.oneshot(req).await.unwrap();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
+    //     let (token, _) = generate_jwt(data.lecturer_user.id, data.lecturer_user.admin);
+    //     let uri = format!(
+    //         "/api/modules/{}/assignments/{}/mark_allocator/generate",
+    //         data.module.id, data.assignment.id
+    //     );
+    //     let req = Request::builder()
+    //         .method("POST")
+    //         .uri(&uri)
+    //         .header("Authorization", format!("Bearer {}", token))
+    //         .body(Body::empty())
+    //         .unwrap();
 
-    #[tokio::test]
-    #[serial]
-    async fn test_post_mark_allocator_missing_memo_output() {
-        setup_assignment_storage_root();
-        let (app, app_state) = make_test_app().await;
-        let data = setup_test_data(app_state.db()).await;
-        
-        let (token, _) = generate_jwt(data.lecturer_user.id, data.lecturer_user.admin);
-        let uri = format!(
-            "/api/modules/{}/assignments/{}/mark_allocator/generate",
-            data.module.id, data.assignment.id
-        );
-        let req = Request::builder()
-            .uri(&uri)
-            .method("POST")
-            .header("Authorization", format!("Bearer {}", token))
-            .header("Content-Type", "application/json")
-            .body(Body::empty())
-            .unwrap();
+    //     let response = app.oneshot(req).await.unwrap();
+    //     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    // }
 
-        let response = app.oneshot(req).await.unwrap();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
+    // #[tokio::test]
+    // #[serial]
+    // async fn test_post_mark_allocator_missing_memo_output() {
+    //     setup_assignment_storage_root();
+    //     let (app, app_state) = make_test_app().await;
+    //     let data = setup_test_data(app_state.db()).await;
+
+    //     let (token, _) = generate_jwt(data.lecturer_user.id, data.lecturer_user.admin);
+    //     let uri = format!(
+    //         "/api/modules/{}/assignments/{}/mark_allocator/generate",
+    //         data.module.id, data.assignment.id
+    //     );
+    //     let req = Request::builder()
+    //         .uri(&uri)
+    //         .method("POST")
+    //         .header("Authorization", format!("Bearer {}", token))
+    //         .header("Content-Type", "application/json")
+    //         .body(Body::empty())
+    //         .unwrap();
+
+    //     let response = app.oneshot(req).await.unwrap();
+    //     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    // }
 }

--- a/backend/marker/src/lib.rs
+++ b/backend/marker/src/lib.rs
@@ -231,7 +231,7 @@ impl<'a> MarkingJob<'a> {
                 return Ok(report.into());
             }
         };
-        //End of temporary fix
+        // TODO - End of temporary fix
 
         let mut all_results: Vec<TaskResult> = Vec::new();
         let mut per_task_results: Vec<Vec<TaskResult>> = Vec::new();

--- a/backend/util/src/execution_config/execution_config.rs
+++ b/backend/util/src/execution_config/execution_config.rs
@@ -36,10 +36,9 @@ pub enum SubmissionMode {
 #[derive(Debug, Clone, Deserialize, Serialize, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum GradingPolicy {
-    Best,   // highest score across submissions
-    Last,   // the most recent submission
+    Best, // highest score across submissions
+    Last, // the most recent submission
 }
-
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ExecutionLimits {
@@ -130,6 +129,20 @@ impl Default for ExecutionOutputOptions {
             stdout: true,
             stderr: false,
             retcode: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodeCoverage {
+    #[serde(default = "default_code_coverage_required")]
+    pub code_coverage_required: u8, // percentage 0-100
+}
+
+impl Default for CodeCoverage {
+    fn default() -> Self {
+        Self {
+            code_coverage_required: default_code_coverage_required(),
         }
     }
 }
@@ -259,6 +272,9 @@ pub struct ExecutionConfig {
 
     #[serde(default)]
     pub gatlam: GATLAM,
+
+    #[serde(default)]
+    pub code_coverage: CodeCoverage,
 }
 
 impl ExecutionConfig {
@@ -269,6 +285,7 @@ impl ExecutionConfig {
             project: ProjectSetup::default(),
             output: ExecutionOutputOptions::default(),
             gatlam: GATLAM::default(),
+            code_coverage: CodeCoverage::default(),
         }
     }
 
@@ -466,4 +483,8 @@ fn default_genes() -> Vec<GeneConfig> {
 
 fn default_submission_mode() -> SubmissionMode {
     SubmissionMode::Manual
+}
+
+fn default_code_coverage_required() -> u8 {
+    80
 }


### PR DESCRIPTION
Added code_coverage system

1) Mark_allocator has been overhauled - it now includes code_coverage and looks like this:
```{
  "generated_at": "2025-09-09T06:49:56.033770285+00:00",
  "tasks": [
    {
      "task1": {
        "code_coverage": false,
        "name": "Untitled Task",
        "subsections": [
          {
            "name": "Task1Subtask1",
            "value": 3
          },
          {
            "name": "Task1Subtask2",
            "value": 3
          },
          {
            "name": "Task1Subtask3",
            "value": 4
          }
        ],
        "task_number": 1,
        "value": 10
      }
    },
    {
      "task2": {
        "code_coverage": true,
        "name": "Untitled Task",
        "subsections": [],
        "task_number": 2,
        "value": 0
      }
    }
  ],
  "total_value": 30
}
```

2) Code coverage added to the ai system
3) Tasks now have a boolean field for marking them as a code-coverage task
4) Removed code_coverage generation from memo_output
5) Integrated submission_code_coverage into the submit endpoint
6) Added code_coverage_report for providing a universal json format

TODO:
1) Marker needs to mark code_coverage
2) Marker needs to ignore code_coverage tasks when not marking code_coverage (in the mark_allocator)