### PR TITLE
Feedback hotfix

### DIFF
--- a/backend/marker/src/feedback/ai_feedback.rs
+++ b/backend/marker/src/feedback/ai_feedback.rs
@@ -154,8 +154,6 @@ impl Feedback for AiFeedback {
                 result.memo_output.join("\n"),
             );
 
-            println!("{}", prompt);
-
             let message = if result.missed_patterns.is_empty() {
                 let student_set: std::collections::HashSet<&String> =
                     result.student_output.iter().collect();


### PR DESCRIPTION
This pull request refines the logic for generating automatic feedback in the `AutoFeedback` strategy by switching from set-based comparisons to multiset (frequency map) comparisons, allowing for more accurate detection of output issues related to duplicate lines. It also removes an unnecessary debug print statement from the AI feedback implementation.

**Feedback logic improvements:**

* Replaced set-based comparisons of student and memo outputs with frequency map (multiset) comparisons in `AutoFeedback`, enabling more precise feedback when outputs contain duplicate lines.
* Updated feedback message selection to use multiset subset and equality checks, improving detection of "Too much output," "Missing lines," and "Incorrect output" cases.

**Code cleanup:**

* Removed unnecessary `println!` debug statement from the `AiFeedback` implementation to tidy up output.

**Imports:**

* Added `HashMap` import to support frequency map logic in `auto_feedback.rs`.