### PR TITLE
Marker infinite loop feedback and marking support

### DIFF
--- a/backend/api/src/routes/modules/assignments/submissions/post.rs
+++ b/backend/api/src/routes/modules/assignments/submissions/post.rs
@@ -256,12 +256,6 @@ pub async fn check_disallowed_code_existing(
     db: &sea_orm::DatabaseConnection,
     assignment: &db::models::assignment::Model,
 ) -> DisallowedCodeCheckResult {
-    println!(
-        "Checking existing submission {} for disallowed code...",
-        submission_id
-    );
-
-    // First, load the existing submission
     let submission = match assignment_submission::Entity::find_by_id(submission_id)
         .one(db)
         .await
@@ -390,11 +384,8 @@ pub async fn check_disallowed_code_new(
     file_hash: &str,
     assignment: &db::models::assignment::Model,
 ) -> DisallowedCodeCheckResult {
-    println!("Checking new submission for disallowed code...");
-
     match scan_code_content::contains_dissalowed_code(file_bytes, config) {
         Ok(true) => {
-            // Load allocator for total marks
             let allocator =
                 match mark_allocator::load_allocator(assignment.module_id, assignment_id) {
                     Ok(a) => a,


### PR DESCRIPTION
This pull request focuses on improving error handling and removing unnecessary debug output in the assignment submission and output parsing logic. The most significant updates are better handling of error markers in output parsing, more robust fallback logic for empty outputs, and cleanup of debug logging in submission checks.

**Error handling improvements in output parsing:**

* Added support for the `&FITCHFORK&Error` marker in `extract_crash_info`, treating content after this marker as `stderr` and returning a non-zero exit code to indicate failure. This enables clearer error reporting for failed tasks.
* Improved logic in `parse_task_output` to handle cases where output is empty but `stderr` or a return code is present, ensuring that subtask outputs are generated appropriately instead of failing outright.

**Debug logging cleanup:**

* Removed unnecessary `println!` debug statements from `check_disallowed_code_existing` and `check_disallowed_code_new` to reduce noise and improve code cleanliness. [[1]](diffhunk://#diff-2ec57fb85e6d5af3d9888fa9a7996e61fd533b6fd892142141239e966984bb5dL259-L264) [[2]](diffhunk://#diff-2ec57fb85e6d5af3d9888fa9a7996e61fd533b6fd892142141239e966984bb5dL393-L397)